### PR TITLE
Fix the usage of `AbortSignal` across the library

### DIFF
--- a/src/db.js
+++ b/src/db.js
@@ -286,6 +286,7 @@ export async function getHistory(psk) {
 export async function clearDB() {
   localStorage.removeItem("lastPos");
   localStorage.removeItem("lastPsk");
+  localStorage.removeItem("blockHeight");
 
   await Dexie.delete("history");
 

--- a/src/node.js
+++ b/src/node.js
@@ -27,7 +27,7 @@ const RKYV_TREE_LEAF_SIZE = process.env.RKYV_TREE_LEAF_SIZE;
 
 // Return a promised rejected if the signal is aborted, resolved otherwise
 const abortable = (signal) =>
-  new Promise((resolve, rejected) =>
+  new Promise((resolve, reject) =>
     signal?.aborted ? reject(signal.reason) : resolve(signal),
   );
 
@@ -183,7 +183,7 @@ export async function sync(wasm, seed, options = {}, node = NODE) {
 
   const { nullifiers, notes, blockHeights, pks, lastPos } = await abortable(
     signal,
-  ).then(() => getOwnedNotes(wasm, seed, buffer, onprogress));
+  ).then(() => getOwnedNotes(wasm, seed, buffer, { onprogress, signal }));
 
   const nullifiersSerialized = await abortable(signal).then(() =>
     getNullifiersRkyvSerialized(wasm, nullifiers),
@@ -268,6 +268,7 @@ export function request(
     method: "POST",
     headers,
     body,
+    signal,
   });
 }
 

--- a/src/wasm.js
+++ b/src/wasm.js
@@ -31,7 +31,7 @@ function decompose(result) {
  * @param {String} function_name Function to call
  * @returns {Promise<Uint8Array>} a promise that resolves to the return value
  */
-export const call = (wasm, args, function_name) =>
+export const call = (wasm, args, function_name, signal) =>
   wasm.task(async (exports, { memcpy }) => {
     const { allocate, free_mem } = exports;
 
@@ -52,7 +52,7 @@ export const call = (wasm, args, function_name) =>
     await free_mem(result.ptr, result.length);
 
     return dest;
-  })();
+  })({ signal });
 
 /**
  * Perform a wasm function call with raw bytes
@@ -61,7 +61,7 @@ export const call = (wasm, args, function_name) =>
  * @param {WebAssembly.ExportValue} function_call name of the function you want to call
  * @returns {Uint8Array} bytes return value of the call
  */
-export const call_raw = (wasm, args, function_name) =>
+export const call_raw = (wasm, args, function_name, signal) =>
   wasm.task(async (exports, { memcpy }) => {
     const { allocate, free_mem } = exports;
     const function_call = exports[function_name];
@@ -79,4 +79,4 @@ export const call_raw = (wasm, args, function_name) =>
     const dest = await memcpy(null, result.ptr, result.length);
     await free_mem(result.ptr, result.length);
     return dest;
-  })();
+  })({ signal });

--- a/tests/mock.js
+++ b/tests/mock.js
@@ -34,6 +34,7 @@ export const createResponse = async (maxItems) => {
  * @param {Function} fn - The function to wrap with mocked fetch.
  * @param {Object} mockOptions - Options to configure the mock behavior.
  * @param {number} [mockOptions.maxItems] - The maximum number of items for the mocked response.
+ * @param {AbortController} [mockOptions.controller] - Controller to abort the signal before provide the mocked response, if provided.
  * @returns {Function} A function that, when called, executes the wrapped function with mocked fetch.
  */
 export function withMockedFetch(fn, mockOptions = {}) {
@@ -47,6 +48,14 @@ export function withMockedFetch(fn, mockOptions = {}) {
       // since only those requests should be mocked (fetching notes
       // from the rusk node)
       if (options?.headers?.["Rusk-Feeder"] === "1") {
+        if (mockOptions.controller) {
+          mockOptions.controller.abort();
+        }
+
+        if (options.signal?.aborted) {
+          return Promise.reject(options.signal.reason);
+        }
+
         // Return a custom response created with the specified maxItems
         return createResponse(mockOptions.maxItems);
       } else {


### PR DESCRIPTION
- Add test for checking abort during syncprogress
- Add test for checking abort during sync's fetch
- Add `mockOptions.controller` to abort during sync's fetch
-  Change block heights checks in "syncprogress more than chunkSize notes" test
- Change `getOwnedNotes` to accept progress' options instead of just `onprogress`
- Change `call_raw` and `call` to accept a `signal` as optional last param
- Change `request` to accept a `signal` as optional last param to proxy to `fetch` #100
- Fix typo in `abortable` function  (`rejected` in `reject`) #101
- Fix `clearDB` to remove `blockHeight` from `localStorage` too

Resolves #100, #101